### PR TITLE
visualize.py AttributeError: 'list' object has no attribute 'shape' bug

### DIFF
--- a/visualize.py
+++ b/visualize.py
@@ -51,7 +51,8 @@ def visualize(data_dirs, wav2mel_path, checkpoint_path, output_path):
             emb = dvector.embed_utterance(mel.to(device))
             emb = emb.detach().cpu().numpy()
         embs.append(emb)
-
+        
+    embs = np.array(emb)
     tsne = TSNE(n_components=2, verbose=1, perplexity=40, n_iter=300)
     transformed = tsne.fit_transform(embs)
 


### PR DESCRIPTION
Hi,

In visualize.py the method **tsne.fit_transform(embs)** should receive a numpy array, not a list.

If embs is a list it calls **def _fit(self, embs, skip_num_points=0):** and the line **emb.shape[0]** throws the error cited in the PR title.

This PR solves it.

Wallace